### PR TITLE
added index route

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import configureStore from './store/configure-store';
-import { Router, Route, browserHistory } from 'react-router'
+import { Router, Route, IndexRoute, browserHistory } from 'react-router'
 import './styles.css';
 import App from './App';
 import Login from './containers/Login';
@@ -15,6 +15,7 @@ ReactDOM.render((
   <Provider store={store}>
     <Router history={browserHistory}>
       <Route path="/" component={App}>
+      	<IndexRoute component={Dashboard}/>
       	<Route path="/login" activeClassName="active" component={Login} />
       	<Route path="/dashboard" activeClassName="active" component={Dashboard} />
       </Route>


### PR DESCRIPTION
This fixed a bug where going to the index route of localhost:3000 would show the header, but neither the dashboard, the login screen, or any way to navigate. 

We added an index route to default to Dashboard. That component will check to see if the user is authenticated and redirect to Login as needed.
